### PR TITLE
Use system waf instead of the out of date waf included with termbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ all: $(PREFIX)/termbox_bindings.so
 	@:
 
 $(TERMBOX_BUILD)/src/libtermbox.%: $(TERMBOX_BUILD)
-	cd $(TERMBOX_PATH) && CFLAGS="$(CFLAGS)" ./waf configure --prefix=. -o $(TERMBOX_BUILD) && ./waf
+	cd $(TERMBOX_PATH) && CFLAGS="$(CFLAGS)" waf configure --prefix=. -o $(TERMBOX_BUILD) && waf
 
 $(PREFIX)/termbox_bindings.so: $(SOURCES) $(PREFIX)
 	$(CC) $(CFLAGS) $(NIF_CFLAGS) $(LDFLAGS) -o $@ $(SOURCES)

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,6 @@ defmodule ExTermbox.Mixfile do
         c_src/termbox_bindings.c
         c_src/termbox/src/*.{inl,c,h}
         c_src/termbox/**/wscript
-        c_src/termbox/waf
         lib
         priv/.keep
         Makefile


### PR DESCRIPTION
This fixes build issues on newer systems, but does require people to install `waf` on their system.

Untested, but this should fix #9 

